### PR TITLE
Add Python3 to older distros

### DIFF
--- a/centos7-systemd/Dockerfile
+++ b/centos7-systemd/Dockerfile
@@ -7,6 +7,7 @@ RUN yum -y update \
       sudo \
       iproute \
       which \
+      python3 \
  && yum clean all
 
 VOLUME ["/sys/fs/cgroup"]

--- a/rhel7-systemd/Dockerfile
+++ b/rhel7-systemd/Dockerfile
@@ -9,6 +9,7 @@ RUN yum makecache fast \
       iproute \
       which \
       wget \
+      python3 \
  && yum clean all
 
 # Add CentOS repositories to cover shortfall in UBI repositories

--- a/rhel8-systemd/Dockerfile
+++ b/rhel8-systemd/Dockerfile
@@ -8,6 +8,7 @@ RUN yum -y update \
       iproute \
       which \
       wget \
+      python3 \
  && yum clean all
 
 # Add RockyLinux repositories to cover shortfall in UBI packages

--- a/rockylinux8-systemd/Dockerfile
+++ b/rockylinux8-systemd/Dockerfile
@@ -17,6 +17,7 @@ RUN yum -y update \
       iproute \
       which \
       procps \
+      python3 \
  && yum clean all
 
 VOLUME ["/sys/fs/cgroup"]


### PR DESCRIPTION
`ansible==10.0.0`  sets default ansible interpreter to `python3`, adding python3 to images that ship with `python2` to avoid manually setting interpreter on those roles 